### PR TITLE
Ensure that a statically-addressed email packet is returned even when a

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -110,6 +110,7 @@ c['schedulers'].append(
     timed.Nightly(name='every1hour',
                   branch='master', # default branch
                   builderNames=[ "DM_stack" ],
+                  properties = { "email": "everyman <lsst-dm-dev@lsstcorp.org>", "branches": "master" },
                   hour=range(0, 24, 1),
 #                  onlyIfChanged=True))
               ))
@@ -313,17 +314,13 @@ def html_MasterFormatter(mode, name, build, results, master_status ):
     # if Build NOT 'forced' && 'success' status, exit without mailing.
     # if Build git-change forced && 'success' status, exit without mailing.
     if result == "failure"  or  ( scheduler == "force" and realName != "everyman" ): 
-         print "BB will send Mail Notification"
-    else:
-         print "BB will not send Notification"
-         return    
-    
-    reason = build.getReason()
-    print buildProperties
-    print "BuildName:%s Result:%s Reason:%s realname:%s  emailAddr:%s" %(name, result, reason, realName, emailAddr)
-    # Following sends out mail to dynamic email list 
-    sender = BUILDBOT_EMAIL
-    message = """\
+         print "BB will send dynamic Mail Notification"
+         reason = build.getReason()
+         print buildProperties
+         print "BuildName:%s Result:%s Reason:%s realname:%s  emailAddr:%s" %(name, result, reason, realName, emailAddr)
+         # Following sends out mail to dynamic email list 
+         sender = BUILDBOT_EMAIL
+         message = """\
 From: %s
 To: %s
 MIME-Version: 1.0
@@ -332,14 +329,16 @@ Subject: %s ... Status summary for your review.
 
 <br>%s
 """ % ( sender, receivers, name, u"\n".join(text) )
-    try:
-        smtpObj = smtplib.SMTP('localhost')
-        smtpObj.sendmail(sender, receivers.split(','), message)
-        print "Successfully sent email to:", receivers
-    except SMTPException:
-        print "Error: unable to send email"
+         try:
+             smtpObj = smtplib.SMTP('localhost')
+             smtpObj.sendmail(sender, receivers.split(','), message)
+             print "Successfully sent email to:", receivers
+         except SMTPException:
+             print "Error: unable to send email"
+    else:
+         print "BB will NOT send dynamic Mail Notification"
 
-# Following sends out the official mailNotifier mail to static email list
+# Always send the official mailNotifier mail to static email list
     return {
         'body': u"\n".join(text),
         'type': 'html'


### PR DESCRIPTION
dynamically-addressed email has also been sent. The mail_notifier
requires the return of a well-formed mail packet on exit.

The email address for the buildbot routine email may need changing prior to merging this commit.

This change has not been tested live. That will happen after the initial review and hand-back.
