### PR TITLE
Tickets/dm 1075

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -290,6 +290,7 @@ def build_mailBody( mode, name, build, result, master_status, buildProperties, b
                         unilist.append(cgi.escape(unicode(line,'utf-8')))
             text.append(u'<pre>'.join([uniline for uniline in unilist]))
             text.append(u'</pre>')
+            text.append(u'<h3>A directory where a build failure occurred is overwritten next build; its failed-build logs are moved to: "%s:%s/%s/"</h4>' % (BUILDBOT_SLAVE8, LDEV_FAILED_LOGS, buildNumber))
     return text,sendTo
 
 # Notify mail_list


### PR DESCRIPTION
DM-1075 to clarify where build log are placed when an error occurs.
Also allowed specific BB admins to terminate a build - needed for diagnostics.
