### PR TITLE
Ensure named structure contains property needed.  (DM-1397)

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -365,9 +365,9 @@ from buildbot.status.web.auth import HTPasswdAuth
 
 def canStopBuild( username, build_status ):
      buildInfo = build_status.getProperties()
-     owner = buildInfo["owner"]
-     print "In: canStopBuild owner: %s username: %s" %( owner, username ) 
-     if owner.startswith(username)  or username in ( 'raa', 'frossie', 'josh'):
+     if "owner" in buildInfo and buildInfo["owner"].startswith(username):
+         return True
+     if username in ('raa', 'frossie', 'josh'):
         return True
      else:
         return False     
@@ -377,9 +377,9 @@ def canStopBuild( username, build_status ):
 
 def canCancelPendingBuild( username, build_request ):
      buildInfo = build_request.original_request.properties.getProperties()
-     owner = buildInfo["owner"]
-     print "In: canCancelPendingBuild owner: %s username: %s" %( owner, username )
-     if owner.startswith(username) or username in ( 'raa', 'frossie', 'josh' ):
+     if "owner" in buildInfo and buildInfo["owner"].startswith(username):
+         return True
+     if username in ('raa', 'frossie', 'josh'):
         return True
      else:
         return False     


### PR DESCRIPTION
The unhandled exceptions occurred  when a forced build was initiated by a not-logged-in user. In this case the named property did not exist in the structure and its unchecked use caused the exception.
