### PR TITLE
disable bi-daily stack build schedule

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -107,15 +107,15 @@ c['schedulers'].append(ForceScheduler(
             StringParameter( name="branches", label="Branches (blank separated):", size=30 )])] 
 ))
 
-c['schedulers'].append(
-    timed.Nightly(name='every1hour',
-                  branch='master', # default branch
-                  builderNames=[ "DM_stack" ],
-                  properties = { "email": "everyman <dm-devel@lists.lsst.org>", "branches": "" },
-                  hour=[1,19],
-                  minute=42,
-#                  onlyIfChanged=True))
-              ))
+#c['schedulers'].append(
+#    timed.Nightly(name='every1hour',
+#                  branch='master', # default branch
+#                  builderNames=[ "DM_stack" ],
+#                  properties = { "email": "everyman <dm-devel@lists.lsst.org>", "branches": "" },
+#                  hour=[1,19],
+#                  minute=42,
+##                  onlyIfChanged=True))
+#              ))
 
 ####### LOCKS
 


### PR DESCRIPTION
Stop buildbot periodically running builds via a timer.  This is to easy
conflicts that may arise from jenkins and buildbot running in parallel
on lsst-dev during a transition period from buildbot -> jenkins.
